### PR TITLE
We either need a dg_id, or a new dg

### DIFF
--- a/app/models/fasta_record.rb
+++ b/app/models/fasta_record.rb
@@ -53,7 +53,8 @@ class FastaRecord < ApplicationRecord
     # fetches dg_id from the cache if it already exists in the database, no harm if it's nil
     dg_id = DetailedGeoLocation.existing_geo_location_ids_by_unique_fields[new_dg.cache_key]
     dg = @new_locations[new_dg.cache_key] # re-use new locations
-    unless dg
+
+    if !dg_id && !dg
       new_dg.save!
       @new_locations[new_dg.cache_key] = new_dg # update new location with one that has an id
       ActiveRecord::Base.logger.info("New location: #{new_dg.cache_key}, id: #{new_dg.id}")


### PR DESCRIPTION
@bwlang, I think this fixes the location duplicate problem. If we already have a dg_id (it's in the database already), then we're good, else if we have a dg (a new location that we've already seen today) then we're good, else we need to save it and store its id.