### PR TITLE
Adding softclip length to coordinate calculation

### DIFF
--- a/lib/parse_alignments.py
+++ b/lib/parse_alignments.py
@@ -24,7 +24,7 @@ for line in sys.stdin:
         type = item[len(item)-1:]
 
         if type == "S":
-            continue
+            None # Don't do anything, but still add the length to query_start below
         elif type != "=":
             if type == "I":
                 print("{}\t{}\t{}\t{}".format(query_name, ref_start, type, query_seq[query_start : query_start + 1]))


### PR DESCRIPTION
I think this is the fix we need for the softclipping issue. The mysterious Spain 'N' variant goes from:
spain	24127	X	TTGGTGATATTGCTGC
 
to:
spain	24159	X	NN
spain	24170	X	NNNNNNNNNNNNNNNN

I won't deploy it before your talk, but we should use it when we rerun the whole dataset.