### PR TITLE
Fixed the blank line crash and refactored filter_duplicates a bit

### DIFF
--- a/lib/filter_duplicates.py
+++ b/lib/filter_duplicates.py
@@ -4,18 +4,20 @@ import re
 
 # Usage: ./filter_duplicates.py <old data> <new data> > <output>
 
-old_set = set([])
-old_records = open(sys.argv[1], "r")
-for line in old_records:
-    regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
-    strain = regex.group(1)
-    old_set.add(strain)
-old_records.close()
+def get_strain(line):
+        regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
+        return regex.group(1)
 
-new_records = open(sys.argv[2], "r")
-for line in new_records:
-    regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
-    strain = regex.group(1)
-    if strain not in old_set:
-        print(line.strip())
-old_records.close()
+old_set = set([])
+with open(sys.argv[1], "r") as old_records:
+    for line in old_records:
+        if line.strip() != "": # skip blank lines
+            strain = get_strain(line)
+            old_set.add(strain)
+
+with open(sys.argv[2], "r") as new_records:
+    for line in new_records:
+        if line.strip() != "": # skip blank lines
+            strain = get_strain(line)
+            if strain not in old_set:
+                print(line.strip())

--- a/lib/filter_duplicates.py
+++ b/lib/filter_duplicates.py
@@ -17,7 +17,8 @@ with open(sys.argv[1], "r") as old_records:
 
 with open(sys.argv[2], "r") as new_records:
     for line in new_records:
-        if line.strip() != "": # skip blank lines
+        line_stripped = line.strip() # so line.strip() isn't called twice
+        if line_stripped != "": # skip blank lines
             strain = get_strain(line)
             if strain not in old_set:
-                print(line.strip())
+                print(line_stripped)

--- a/lib/filter_duplicates.py
+++ b/lib/filter_duplicates.py
@@ -5,8 +5,8 @@ import re
 # Usage: ./filter_duplicates.py <old data> <new data> > <output>
 
 def get_strain(line):
-        regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
-        return regex.group(1)
+    regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
+    return regex.group(1)
 
 old_set = set([])
 with open(sys.argv[1], "r") as old_records:


### PR DESCRIPTION
I've fixed the bug where filter_duplicates.py will crash if there is a blank line in either input file, by adding a check that the line has something other than whitespace before processing it.

I also refactored some things I noticed while doing that:

1) I moved the regex code out into a function, so the regex isn't included twice in the code anymore.

2) I changed the `file.open()` and `file.close()` to a `with open(...) as...` block (doesn't really have a big effect here, but does ensure the file gets closed in case of errors). While doing this, I also noticed that the code actually closed old_records twice and never closed new_records.