### PR TITLE
Fix same day dups

### DIFF
--- a/lib/filter_duplicates.py
+++ b/lib/filter_duplicates.py
@@ -8,17 +8,18 @@ def get_strain(line):
     regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
     return regex.group(1)
 
-old_set = set([])
+record_set = set([])
 with open(sys.argv[1], "r") as old_records:
     for line in old_records:
         if line.strip() != "": # skip blank lines
             strain = get_strain(line)
-            old_set.add(strain)
+            record_set.add(strain)
 
 with open(sys.argv[2], "r") as new_records:
     for line in new_records:
         line_stripped = line.strip() # so line.strip() isn't called twice
         if line_stripped != "": # skip blank lines
             strain = get_strain(line)
-            if strain not in old_set:
+            if strain not in record_set:
                 print(line_stripped)
+                record_set.add(strain) # do not output two of the same record, old or new


### PR DESCRIPTION
Made a minor change that prevents two sequences with the same name being added, even if they're in the same day's new data.