### PR TITLE
Added code to mimic ncov-ingest formatting changes.

### DIFF
--- a/lib/filter_duplicates.py
+++ b/lib/filter_duplicates.py
@@ -6,7 +6,11 @@ import re
 
 def get_strain(line):
     regex = re.search('\"covv_virus_name\": \"(.*?)\",', line)
-    return regex.group(1)
+    strain_name = regex.group(1)
+    # do the same transformations ncov-ingest will do to ensure they don't create undetected dups
+    strain_name = re.sub("\s", "", strain_name)
+    strain_name = re.sub("^[nh]CoV-19/", "", strain_name)
+    return strain_name
 
 record_set = set([])
 with open(sys.argv[1], "r") as old_records:


### PR DESCRIPTION
I just added a few lines to format the sequence names in the "seen" list using regexes like the one ncov-ingest uses, so that the duplicate checking does the _exact_ same changes here, to prevent stuff like that "duplicate" where one had a space and the other doesn't.

I haven't tested the script itself just yet, I'm doing that shortly and will comment once I've done so.
