### PR TITLE
Added DSL1 specification to workflow.

### DIFF
--- a/lib/summarize_variants.nf
+++ b/lib/summarize_variants.nf
@@ -1,3 +1,5 @@
+nextflow.enable.dsl = 1
+
 ref = params.ref 
 ref = file(ref).toAbsolutePath()
 params.prev_json=


### PR DESCRIPTION
Just adds `nextflow.enable.dsl = 1` to the workflow so it can still run as DSL1 on the newer Nextflow it will be using with my other PR.

This is intended to be temporary, as I already have a DSL2 version on another branch with the Pangolin stuff in it, and when that's merged this will move to DSL2.