### PR TITLE
Variant coords -> BED format

### DIFF
--- a/app/models/variant_site.rb
+++ b/app/models/variant_site.rb
@@ -17,6 +17,8 @@ class VariantSite < ApplicationRecord
       fasta_record_id = FastaRecord.existing_fasta_strain_ids[strain]
       raise "Failed to find fasta record for strain: #{strain}" unless fasta_record_id
 
+      ref_pos = (Integer(ref_pos) - 1).to_s # convert 1-based to 0-based
+
       ref_end = Integer(ref_pos) + variant.length
       variant = "#{variant.length}-" if variant_type.include? 'D'
       variant = "#{variant.length}N" if variant.include? 'N'

--- a/app/models/variant_site.rb
+++ b/app/models/variant_site.rb
@@ -17,12 +17,12 @@ class VariantSite < ApplicationRecord
       fasta_record_id = FastaRecord.existing_fasta_strain_ids[strain]
       raise "Failed to find fasta record for strain: #{strain}" unless fasta_record_id
 
-      ref_pos = (Integer(ref_pos) - 1).to_s # convert 1-based to 0-based
+      ref_pos = Integer(ref_pos) - 1 # convert 1-based to 0-based
 
-      ref_end = Integer(ref_pos) + variant.length
+      ref_end = ref_pos + variant.length
       variant = "#{variant.length}-" if variant_type.include? 'D'
       variant = "#{variant.length}N" if variant.include? 'N'
-      variants << VariantSite.new(ref_start: ref_pos, ref_end: ref_end, variant_type: variant_type,
+      variants << VariantSite.new(ref_start: ref_pos.to_s, ref_end: ref_end, variant_type: variant_type,
                                   variant: variant, fasta_record_id: fasta_record_id)
     end
 


### PR DESCRIPTION
Currently the variant start pos is from the SAM file (i.e. 1-based), and the end pos is the start pos + the length (i.e. half-open).

This basically just subtracts 1 from the start (and by extension, the end) to make it BED-style.

Note: Don't _deploy_ this (merging isn't an issue) until I run the SQL to retroactively fix the old ones, because if this runs before I fix those, it'll create a gigantic mess of mismatched positions.