### PR TITLE
"<ge></ge>netic" on the about page

### DIFF
--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -27,7 +27,7 @@
     <p>
       We would like to thank the GISAID Initiative and are grateful to all of the data contributors,
       i.e.the Authors, the Originating laboratories responsible for obtaining the specimens,
-      and the Submitting laboratories for generating the <ge></ge>netic sequence and metadata
+      and the Submitting laboratories for generating the genetic sequence and metadata
       and sharing via the GISAID Initiative, on which this research is based.
     </p>
     <p>


### PR DESCRIPTION
I fixed a sentence on the about page where it said "`and the Submitting laboratories for generating the <ge></ge>netic sequence and metadata`" in the source, and read "and the Submitting laboratories for generating the netic sequence and metadata" when you viewed the page.