### PR TITLE
.pgpass support

### DIFF
--- a/lib/summarize_variants.nf
+++ b/lib/summarize_variants.nf
@@ -144,7 +144,7 @@ process load_pangolin_data {
         file('*.complete_pangolin') into complete_files_pangolin
     shell:
     '''
-    !{primer_monitor_path}/lib/pangolin_calls/update_fasta_records.sh !{csv}
+    PGPASSFILE="!{primer_monitor_path}/config/.pgpass" !{primer_monitor_path}/lib/pangolin_calls/update_fasta_records.sh !{csv}
     '''
 }
 


### PR DESCRIPTION
The Pangolin calls upload script now gets passed the location of a .pgpass in PGPASSFILE so that it can authenticate with the database properly.