### PR TITLE
Set Nextflow to use Mamba & and store Pangolin version

### DIFF
--- a/db/migrate/20230127154500_add_pangolin_version_to_fasta_records.rb
+++ b/db/migrate/20230127154500_add_pangolin_version_to_fasta_records.rb
@@ -1,0 +1,9 @@
+class AddSubmittedDateToFastaRecords < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :fasta_records, :pangolin_version, :text
+  end
+
+  def self.down
+    remove_column :fasta_records, :pangolin_version
+  end
+end

--- a/lib/n_processing/extract_ns.sh
+++ b/lib/n_processing/extract_ns.sh
@@ -6,4 +6,4 @@ if (($# < 1)); then # if N variants file provided
 fi
 # you need to export DB_HOST, DB_NAME, and DB_USER before running this
 
-psql -h "$DB_HOST" -d "$DB_NAME" -U "$DB_USER" -c "SELECT variant_sites.ref_start, variant_sites.ref_end, fasta_records.strain, fasta_records.date_collected, variant_sites.variant_type, variant_sites.variant FROM variant_sites INNER JOIN fasta_records ON fasta_records.id=variant_sites.fasta_record_id WHERE (date_collected >= '$1' OR (date_collected IS NULL AND date_submitted >= '$1')) AND variant LIKE '%N%';" --csv -t | tr "," "\t" | sed -E "s/^/NC_045512.2\t/g"
+psql -h "$DB_HOST" -d "$DB_NAME" -U "$DB_USER" -c "SELECT variant_sites.ref_start, variant_sites.ref_end, fasta_records.strain, fasta_records.pangolin_lineage, fasta_records.date_collected, variant_sites.variant_type, variant_sites.variant FROM variant_sites INNER JOIN fasta_records ON fasta_records.id=variant_sites.fasta_record_id WHERE (date_collected >= '$1' OR (date_collected IS NULL AND date_submitted >= '$1')) AND variant LIKE '%N%';" --csv -t | tr "," "\t" | sed -E "s/^/NC_045512.2\t/g"

--- a/lib/n_processing/process_unique_ns.py
+++ b/lib/n_processing/process_unique_ns.py
@@ -4,6 +4,8 @@ region_n_counts = {}
 
 seqs_to_dates = {}
 
+seqs_to_lineages = {}
+
 regions_to_pos = {}
 
 if len(sys.argv) < 2:
@@ -21,15 +23,17 @@ with open(sys.argv[1]) as f:
     for line in f:
         variant = [field.strip() for field in line.split("\t")]
         if variant[4] not in seqs_to_dates:
-            seqs_to_dates[variant[4]] = variant[5]
+            seqs_to_dates[variant[4]] = variant[6]
+        if variant[4] not in seqs_to_lineages:
+            seqs_to_lineages[variant[4]] = variant[5]
         if variant[3] not in regions_to_pos:
             regions_to_pos[variant[3]] = [variant[1], variant[2]]
         if variant[3] not in region_n_counts:
-            region_n_counts[variant[3]] = {variant[4]: int(variant[6])}
+            region_n_counts[variant[3]] = {variant[4]: int(variant[7])}
         elif variant[4] not in region_n_counts[variant[3]]:
-            region_n_counts[variant[3]][variant[4]] = int(variant[6])
+            region_n_counts[variant[3]][variant[4]] = int(variant[7])
         else:
-            region_n_counts[variant[3]][variant[4]] += int(variant[6])
+            region_n_counts[variant[3]][variant[4]] += int(variant[7])
 
 for region in region_n_counts:
     for seq in region_n_counts[region]:
@@ -50,6 +54,8 @@ for region in region_n_counts:
                 + region_set_name
                 + "\t"
                 + seq
+                + "\t"
+                + seqs_to_lineages[seq]
                 + "\t"
                 + seqs_to_dates[seq]
                 + "\t"

--- a/lib/n_processing/process_unique_region_ns.sh
+++ b/lib/n_processing/process_unique_region_ns.sh
@@ -3,6 +3,6 @@
 mkfifo $$_unique_regions;
 mkfifo $$_unique_ns;
 python3 get_unique_regions.py "$1" "$2" > $$_unique_regions & # get the regions that belong to only one amplicon
-bedtools intersect -wo -a $$_unique_regions -b "$3" | cut -f 1,2,3,4,8,9,12 > $$_unique_ns & # get Ns in unique regions
+bedtools intersect -wo -a $$_unique_regions -b "$3" | cut -f 1,2,3,4,8,9,12,13 > $$_unique_ns & # get Ns in unique regions
 python process_unique_ns.py $$_unique_ns "$4"; # process this to get the number and fraction of Ns in the region and handle the N fraction cutoff
 rm $$_unique_regions $$_unique_ns;

--- a/lib/nextflow.config
+++ b/lib/nextflow.config
@@ -1,3 +1,4 @@
 process.executor = 'sge'
 process.penv = 'smp'
 conda.enabled = true
+conda.useMamba = true

--- a/lib/pangolin_calls/update_fasta_records.sh
+++ b/lib/pangolin_calls/update_fasta_records.sh
@@ -8,9 +8,9 @@ fi
 source ../../.env;
 
 psql -h "$DB_HOST" -d "$DB_NAME" -U "$DB_USER" >&2 <<CMDS;
-CREATE TEMPORARY TABLE pangolin_tmp (taxon varchar NOT NULL, lineage varchar NOT NULL, conflict varchar, ambiguity_score float4, scorpio_call varchar, scorpio_support numeric, scorpio_conflict numeric, scorpio_notes text, version varchar NOT NULL, pangolin_version date NOT NULL, scorpio_version varchar NOT NULL, constellation_version varchar NOT NULL, is_designated text NOT NULL, qc_status varchar, qc_notes varchar, note varchar);
+CREATE TEMPORARY TABLE pangolin_tmp (taxon varchar NOT NULL, lineage varchar NOT NULL, conflict varchar, ambiguity_score float4, scorpio_call varchar, scorpio_support numeric, scorpio_conflict numeric, scorpio_notes text, version varchar NOT NULL, pangolin_version varchar NOT NULL, scorpio_version varchar NOT NULL, constellation_version varchar NOT NULL, is_designated text NOT NULL, qc_status varchar, qc_notes varchar, note varchar);
 \copy pangolin_tmp from '$1' WITH (format csv, header on);
-UPDATE fasta_records SET pangolin_lineage=pangolin_tmp.lineage FROM pangolin_tmp WHERE pangolin_tmp.taxon=fasta_records.strain;
+UPDATE fasta_records SET pangolin_lineage=pangolin_tmp.lineage, pangolin_version=pangolin_tmp.pangolin_version FROM pangolin_tmp WHERE pangolin_tmp.taxon=fasta_records.strain;
 DROP TABLE pangolin_tmp;
 CMDS
 


### PR DESCRIPTION
Sets Nextflow to use mamba instead of conda for installing conda packages (known working, I hotfixed it days ago), _and_ stores the pangolin version in the table (untested).