### PR TITLE
Fixed migration class name.

### DIFF
--- a/db/migrate/20230127154500_add_pangolin_version_to_fasta_records.rb
+++ b/db/migrate/20230127154500_add_pangolin_version_to_fasta_records.rb
@@ -1,4 +1,4 @@
-class AddSubmittedDateToFastaRecords < ActiveRecord::Migration[6.1]
+class AddPangolinVersionToFastaRecords < ActiveRecord::Migration[6.1]
   def self.up
     add_column :fasta_records, :pangolin_version, :text
   end


### PR DESCRIPTION
The migration merged in #78 has the wrong class name and will not run. This fixes it.