### PR TITLE
Bulk add primers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -123,3 +123,7 @@ ul {
   list-style: unset;
 }
 
+.white-button
+{
+  background-color: white;
+}

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -26,13 +26,13 @@ function addPrimer(lastPrimer)
         console.log("Testing: "+child.tagName+", "+child.id);
         if(child.tagName.toUpperCase() === "INPUT")
         {
-            if(child.id.endsWith("name"))
-            {
-                child.value = longName;
-            }
-            else if(child.id.endsWith("short_name"))
+            if(child.id.endsWith("short_name"))
             {
                 child.value = shortName;
+            }
+            else if(child.id.endsWith("name"))
+            {
+                child.value = longName;
             }
             else if(child.id.endsWith("sequence"))
             {
@@ -54,7 +54,7 @@ function processFasta(fastaText)
         let seqDataRaw = seq.split("\n");
         let longName = seqDataRaw[0];
         let sequence = seqDataRaw.slice(1).join("");
-        let shortName = longName.split(" ")[0];
+        let shortName = longName.split(" ")[0].slice(0,5);
         let createOligo = $('.add_fields')[0];
         createOligo.click.call(createOligo);
         addPrimer([longName, shortName, sequence]);

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -1,5 +1,7 @@
 const $ = require("jquery");
 
+
+
 $(document).ready(function(){
 
     const fasta_upload = $('#fasta_upload');
@@ -7,6 +9,14 @@ $(document).ready(function(){
     fasta_upload.on('change', function(){
         if(fasta_upload[0].files.length > 0)
         {
+            if($('#fasta_name').length === 0)
+            {
+                const fastaName = document.createElement("span");
+                fastaName.id = 'fasta_name';
+                fastaName.className = 'file-name';
+                $('#fasta_upload_label')[0].appendChild(fastaName);
+                $('#fasta_div').addClass('has-name');
+            }
             $('#fasta_name')[0].innerHTML = fasta_upload[0].files[0].name;
             fasta_upload[0].files[0].text().then(processFasta);
         }

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -44,9 +44,10 @@ function addPrimer(lastPrimer)
 
 function processFasta(fastaText)
 {
+    const fastaName = $('#fasta_name')[0].innerHTML;
     if(fastaText[0] !== ">")
     {
-        alert("invalid FASTA!");
+        alert("'"+fastaName+"' is not a valid FASTA file!");
         return;
     }
     fastaText.slice(1).split("\n>").forEach(function(seq){

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -64,7 +64,7 @@ function processFasta(fastaText)
         let longName = seqDataRaw[0];
         let sequence = seqDataRaw.slice(1).join("");
         let shortName = longName.split(" ")[0].slice(0,5);
-        const invalidSeqRE = /[^autcgnbvdhrykmws\-]/i; //matches everything except for all bases and ambiguity codes plus - for gap
+        const invalidSeqRE = /([^autcgnbvdhrykmws\-]|\s)/i; //matches everything except for all bases and ambiguity codes, - (for gaps), and whitespace
         if(sequence.match(invalidSeqRE) !== null)
         {
             confirm("Non-sequence character detected in file '"+fastaName+"'.\n\nSequence:\n>"+seq+"\n\nContinue?");

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -64,6 +64,11 @@ function processFasta(fastaText)
         let longName = seqDataRaw[0];
         let sequence = seqDataRaw.slice(1).join("");
         let shortName = longName.split(" ")[0].slice(0,5);
+        const invalidSeqRE = /[^autcgnbvdhrykmws\-]/i; //matches everything except for all bases and ambiguity codes plus - for gap
+        if(sequence.match(invalidSeqRE) !== null)
+        {
+            confirm("Non-sequence character detected in file '"+fastaName+"'.\n\nSequence:\n>"+seq+"\n\nContinue?");
+        }
         let createOligo = $('.add_fields')[0];
         createOligo.click.call(createOligo);
         addPrimer([longName, shortName, sequence]);

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -64,7 +64,7 @@ function processFasta(fastaText)
         let longName = seqDataRaw[0];
         let sequence = seqDataRaw.slice(1).join("");
         let shortName = longName.split(" ")[0].slice(0,5);
-        const invalidSeqRE = /([^autcgnbvdhrykmws\-]|\s)/i; //matches everything except for all bases and ambiguity codes, - (for gaps), and whitespace
+        const invalidSeqRE = /([^autcgnbvdhrykmws\- \t])/i; //matches everything except for all bases and ambiguity codes, - (for gaps), and whitespace
         if(sequence.match(invalidSeqRE) !== null)
         {
             confirm("Non-sequence character detected in file '"+fastaName+"'.\n\nSequence:\n>"+seq+"\n\nContinue?");

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -23,7 +23,6 @@ function addPrimer(lastPrimer)
     let newPrimerContainer = $('#samples > div:nth-last-of-type(2) > div.field-body')[0];
     for(const child of newPrimerContainer.children)
     {
-        console.log("Testing: "+child.tagName+", "+child.id);
         if(child.tagName.toUpperCase() === "INPUT")
         {
             if(child.id.endsWith("short_name"))

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -64,7 +64,7 @@ function processFasta(fastaText)
         let longName = seqDataRaw[0];
         let sequence = seqDataRaw.slice(1).join("");
         let shortName = longName.split(" ")[0].slice(0,5);
-        const invalidSeqRE = /([^autcgnbvdhrykmws\- \t])/i; //matches everything except for all bases and ambiguity codes, - (for gaps), and whitespace
+        const invalidSeqRE = /[^autcgnbvdhrykmws\- \t]/i; //matches everything except for all bases and ambiguity codes, - (for gaps), and whitespace
         if(sequence.match(invalidSeqRE) !== null)
         {
             confirm("Non-sequence character detected in file '"+fastaName+"'.\n\nSequence:\n>"+seq+"\n\nContinue?");

--- a/app/javascript/packs/primer_sets.js
+++ b/app/javascript/packs/primer_sets.js
@@ -1,0 +1,61 @@
+const $ = require("jquery");
+
+$(document).ready(function(){
+
+    const fasta_upload = $('#fasta_upload');
+
+    fasta_upload.on('change', function(){
+        if(fasta_upload[0].files.length > 0)
+        {
+            $('#fasta_name')[0].innerHTML = fasta_upload[0].files[0].name;
+            fasta_upload[0].files[0].text().then(processFasta);
+        }
+    });
+
+
+});
+
+function addPrimer(lastPrimer)
+{
+    let longName = lastPrimer[0];
+    let shortName = lastPrimer[1];
+    let sequence = lastPrimer[2];
+    let newPrimerContainer = $('#samples > div:nth-last-of-type(2) > div.field-body')[0];
+    for(const child of newPrimerContainer.children)
+    {
+        console.log("Testing: "+child.tagName+", "+child.id);
+        if(child.tagName.toUpperCase() === "INPUT")
+        {
+            if(child.id.endsWith("name"))
+            {
+                child.value = longName;
+            }
+            else if(child.id.endsWith("short_name"))
+            {
+                child.value = shortName;
+            }
+            else if(child.id.endsWith("sequence"))
+            {
+                child.value = sequence;
+            }
+        }
+    }
+}
+
+function processFasta(fastaText)
+{
+    if(fastaText[0] !== ">")
+    {
+        alert("invalid FASTA!");
+        return;
+    }
+    fastaText.slice(1).split("\n>").forEach(function(seq){
+        let seqDataRaw = seq.split("\n");
+        let longName = seqDataRaw[0];
+        let sequence = seqDataRaw.slice(1).join("");
+        let shortName = longName.split(" ")[0];
+        let createOligo = $('.add_fields')[0];
+        createOligo.click.call(createOligo);
+        addPrimer([longName, shortName, sequence]);
+    })
+}

--- a/app/views/primer_sets/_form.html.erb
+++ b/app/views/primer_sets/_form.html.erb
@@ -70,8 +70,20 @@
         <%= form.fields_for :oligos do |es| %>
           <%= render 'oligo_fields', f: es %>
         <% end %>
-        <p>
+        <p id="add-new">
           <%= link_to_add_association 'Add Oligo', form, :oligos, class:'button' %>
+        <div class="file has-name">
+          <label class="file-label">
+            <input class="file-input" type="file" name="fasta" id="fasta_upload">
+            <span class="file-cta white-button">
+              <span class="file-label">
+                Upload FASTA...
+              </span>
+            </span>
+            <span class="file-name" id="fasta_name">
+            </span>
+          </label>
+        </div>
         </p>
       </div>
     </div>
@@ -83,3 +95,5 @@
     <%= form.submit class: 'button is-link'%>
   </div>
 <% end %>
+
+<%= javascript_pack_tag "primer_sets" %>

--- a/app/views/primer_sets/_form.html.erb
+++ b/app/views/primer_sets/_form.html.erb
@@ -72,15 +72,13 @@
         <% end %>
         <p id="add-new">
           <%= link_to_add_association 'Add Oligo', form, :oligos, class:'button' %>
-        <div class="file has-name">
-          <label class="file-label">
+        <div class="file" id="fasta_div">
+          <label class="file-label" id="fasta_upload_label">
             <input class="file-input" type="file" name="fasta" id="fasta_upload">
             <span class="file-cta white-button">
               <span class="file-label">
                 Upload FASTA...
               </span>
-            </span>
-            <span class="file-name" id="fasta_name">
             </span>
           </label>
         </div>


### PR DESCRIPTION
Just adds a small feature to enable loading in every primer in a FASTA file automatically instead of typing each one in by hand, so adding large primer sets is easier.

It seems to work, but there might still be some bug I've missed.