### PR TITLE
Fixed errbit.

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -25,6 +25,7 @@ Airbrake.configure do |c|
   c.job_stats           = false
   c.query_stats         = false
   c.performance_stats   = false
+  c.remote_config       = false
 
   # Configures the root directory of your project. Expects a String or a
   # Pathname, which represents the path to your project. Providing this option


### PR DESCRIPTION
I've made one small change to get errbit back online.

I added `c.remote_config = false` to the initializer because the new version of `airbrake` was incorrectly pinging airbrake.io (not our errbit server) for some feature called "remote config" (which errbit doesn't do as far as I know), being told the project didn't exist, and shutting down error reporting.